### PR TITLE
Makefile.in: handle LDFLAGS passed to the configure script

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -14,6 +14,7 @@
 CC	= @CC@
 STRIP	?= $(CROSS)strip
 CFLAGS	= @CFLAGS@
+LDFLAGS	= @LDFLAGS@
 INSTALL	= @INSTALL@
 LIBS	= @LIBS@
 
@@ -50,7 +51,7 @@ SIM_LIBS:=-levent
 SIM_CFLAGS:=-Wno-unused
 
 ifeq ($(OS),DARWIN)
-LDFLAGS:=-dynamiclib -Wl,-dylib_install_name -Wl,$(LIB_SONAME)
+LDFLAGS+=-dynamiclib -Wl,-dylib_install_name -Wl,$(LIB_SONAME)
 endif
 
 LIBS:=$(LDFLAGS) $(LIBS)


### PR DESCRIPTION
Taking in account CFLAGS and LDFLAGS passed to the configure script is a
common behaviour.

This fix is also useful for supporting the per-package staging directory
within Buildroot.

Signed-off-by: Fabio Porcedda <Fabio Porcedda fabio.porcedda@gmail>