### PR TITLE
Changes for better IEEE 1901-2010 compliance in sniffer mode

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -14,6 +14,7 @@
 CC	= @CC@
 STRIP	?= $(CROSS)strip
 CFLAGS	= @CFLAGS@
+LDFLAGS	= @LDFLAGS@
 INSTALL	= @INSTALL@
 LIBS	= @LIBS@
 
@@ -50,7 +51,7 @@ SIM_LIBS:=-levent
 SIM_CFLAGS:=-Wno-unused
 
 ifeq ($(OS),DARWIN)
-LDFLAGS:=-dynamiclib -Wl,-dylib_install_name -Wl,$(LIB_SONAME)
+LDFLAGS+=-dynamiclib -Wl,-dylib_install_name -Wl,$(LIB_SONAME)
 endif
 
 LIBS:=$(LDFLAGS) $(LIBS)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# faifa
+Faifa can configure any Intellon-based Power Line Communication device using Intellon INT5000 and INT6000 
+series chips (6000 and 6300 chips). 
+
+It supports all Intellon-specific management and control frames as well as standard management frames. 
+
+This fork has been made in order to better decode HP-AV frames in sniffer mode according to the IEEE 1901-2010 standard.
+
+Specifically, the modules homeplug_av.h and frame.c have had structures and functions added for decoding frames 
+differentially according to delimiter type, and also for decoding beacon MPDU payload. 
+
+Various changes made to better describe fields and give values in both decimal and hex (and occasionally binary).
+
+Tested using Debian GNU/Linux 8 with a variety of Homeplug adapters having both QCA and Broadcmm chipsets.
+
+(Obviously, the Broadcom chipsets don't implement the Intellon/QCA proprietary sniffer mode, but the frames they 
+emit can be successfully sniffed once an Intellon/QCA adapter is added to a Broadcmm Homeplug network).

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ differentially according to delimiter type, and also for decoding beacon MPDU pa
 
 Various changes made to better describe fields and give values in both decimal and hex (and occasionally binary).
 
-Tested using Debian GNU/Linux 8 with a variety of Homeplug adapters having both QCA and Broadcmm chipsets.
+Tested using Debian GNU/Linux 8 with a variety of Homeplug adapters having both QCA and Broadcom chipsets.
 
 (Obviously, the Broadcom chipsets don't implement the Intellon/QCA proprietary sniffer mode, but the frames they 
-emit can be successfully sniffed once an Intellon/QCA adapter is added to a Broadcmm Homeplug network).
+emit can be successfully sniffed once an Intellon/QCA adapter is added to a Broadcom Homeplug network).

--- a/configure.in
+++ b/configure.in
@@ -38,5 +38,8 @@ AC_CHECK_LIB(pcap, pcap_lookupdev,
 	AC_MSG_ERROR(You need pcap_datalink check your libpcap))],
 	AC_MSG_ERROR(You need pcap_lookupdev check your libpcap))
 
+AC_CHECK_HEADERS([event.h],,[AC_MSG_ERROR([You need libevent development files])])
+AC_CHECK_HEADERS([event2/util.h],,[AC_MSG_ERROR([You need libevent development files])])
+
 AC_CONFIG_HEADER(config.h)
 AC_OUTPUT(Makefile)

--- a/frame.c
+++ b/frame.c
@@ -609,7 +609,7 @@ static int hpav_init_read_mod_data_request(void *buf, int len, void *UNUSED(buff
 	faifa_printf(out_stream, "Length? ");
 	fscanf(in_stream, "%hu", &(mm->length));
 	faifa_printf(out_stream, "Offset? ");
-	fscanf(in_stream, "%u ", &(mm->offset));
+	fscanf(in_stream, "%u", &(mm->offset));
 
 	avail -= sizeof(*mm);
 	return (len - avail);
@@ -751,15 +751,15 @@ static int hpav_dump_get_devices_attrs_confirm(void *buf, int len, struct ether_
 		goto out;
 		break;
 	}
-	faifa_printf(out_stream, "Cookie: %u \n", mm->cookie);
+	faifa_printf(out_stream, "Cookie: %u\n", mm->cookie);
 	faifa_printf(out_stream, "Report type: %s\n", mm->rtype ? "XML" : "Binary");
 	faifa_printf(out_stream, "Size: %d\n", mm->size);
 	faifa_printf(out_stream, "Hardware: %s\n", mm->fmt.hardware);
 	faifa_printf(out_stream, "Software: %s\n", mm->fmt.software);
-	faifa_printf(out_stream, "Major: %u \n", mm->fmt.major);
-	faifa_printf(out_stream, "Minor: %u \n", mm->fmt.minor);
-	faifa_printf(out_stream, "Subversion: %u \n", mm->fmt.subversion);
-	faifa_printf(out_stream, "Build number: %u \n", mm->fmt.build_number);
+	faifa_printf(out_stream, "Major: %u\n", mm->fmt.major);
+	faifa_printf(out_stream, "Minor: %u\n", mm->fmt.minor);
+	faifa_printf(out_stream, "Subversion: %u\n", mm->fmt.subversion);
+	faifa_printf(out_stream, "Build number: %u\n", mm->fmt.build_number);
 	faifa_printf(out_stream, "Build date: %s\n", mm->fmt.build_date);
 	faifa_printf(out_stream, "Release type: %s\n", mm->fmt.release_type);
 
@@ -1015,7 +1015,7 @@ static void dump_rx_link_stats(struct rx_link_stats *rx)
 		faifa_printf(out_stream, "-- Rx interval %d --\n", i);
 		faifa_printf(out_stream, "Rx PHY rate.....................: %02hhd\n",
 				rx->rx_interval_stats[i].phyrate);
-		faifa_printf(out_stream, "PB received successfully........: %"SCNu64"\n",
+		faifa_printf(out_stream, "PB received successfully........: %"SCNu64"n",
 				rx->rx_interval_stats[i].pb_passed);
 		faifa_printf(out_stream, "PB received failed..............: %"SCNu64"\n",
 				rx->rx_interval_stats[i].pb_failed);
@@ -1470,8 +1470,8 @@ void dump_beacon_mpdu_payload (struct beacon_mpdu_payload *bmp)
 	faifa_printf (out_stream,  "Beacon Payload Check Sequence: %04x\n",(u_int32_t)(bmp->bpcs));		// 132-135
 }
 
-/* The following functions include amendments (c) Andrew Margolis to make faifa conform better to 
-   IEEE 1901-2010 standards by decoded all six possible delimiters in sniffed frames properly.*/
+/* The following function includes amendments (c) Andrew Margolis to make faifa conform better to 
+   IEEE 1901-2010 standards by decoding all six possible delimiters in sniffed frames properly.*/
 
 static int hpav_dump_sniffer_indicate(void *buf, int len, struct ether_header *UNUSED(hdr))
 {
@@ -1624,8 +1624,8 @@ static int hpav_dump_check_points_indicate(void *buf, int len, struct ether_head
 	faifa_printf(out_stream, "Major: %s\n", mm->major ? "< 1.4" : "> 1.4");
 	faifa_printf(out_stream, "Checkpoint buffer locked: %s\n", mm->buf_locked ? "Yes" : "No");
 	faifa_printf(out_stream, "Auto-lock on reset supported: %s\n", mm->auto_lock ? "Yes" : "No");
-	faifa_printf(out_stream, "Unsolicited update supported: %s\n", mm->unsoc_upd ? "Yes" : "No");
-	faifa_printf(out_stream, "Unsolicited: %s\n", mm->unsoc ? "Yes" : "No");
+	faifa_printf(out_stream, "Unsollicited update supported: %s\n", mm->unsoc_upd ? "Yes" : "No");
+	faifa_printf(out_stream, "Unsollicited: %s\n", mm->unsoc ? "Yes" : "No");
 	faifa_printf(out_stream, "Session: %04hx\n", mm->session_id);
 	faifa_printf(out_stream, "Length: %u (0x%08x)\n", mm->length, mm->length);
 	faifa_printf(out_stream, "Offset: 0x%08x\n", mm->offset);

--- a/homeplug_av.h
+++ b/homeplug_av.h
@@ -7,7 +7,7 @@
  *
  *	Modifications by Andrew Margolis (c) 2015 to produce human-readable MPDU frame 
  *	control fields and Beacon MPDU payload fields in accordance with the IEEE 
- *   1901-2010 Powerline standard.
+ *  1901-2010 Powerline standard.
  *							 
  *  The BSD License
  *  ===============

--- a/main.c
+++ b/main.c
@@ -5,6 +5,10 @@
  *		    	    Florian Fainelli <florian@openwrt.org>
  *			    Nicolas Thill <nico@openwrt.org>
  *
+ *	Modifications by Andrew Margolis (c) 2015 to produce human-readable MPDU frame 
+ *	control fields and Beacon MPDU payload fields in accordance with the IEEE 
+ *   1901-2010 Powerline standard - changes made to modules frame.c and homepluf_av.h.
+ *
  *  The BSD License
  *  ===============
  *  Redistribution and use in source and binary forms, with or without
@@ -115,6 +119,7 @@ int main(int argc, char **argv)
 	u_int8_t addr[ETHER_ADDR_LEN] = { 0 };
 
 	fprintf(stdout, "Faifa for HomePlug AV (GIT revision %s)\n\n", GIT_REV);
+	fprintf(stdout, "Modifications for better IEEE-1901-2010 conformance by Andrew Margolis\n\n");
 
 	if (argc < 2) {
 		usage();

--- a/main.c
+++ b/main.c
@@ -119,7 +119,6 @@ int main(int argc, char **argv)
 	u_int8_t addr[ETHER_ADDR_LEN] = { 0 };
 
 	fprintf(stdout, "Faifa for HomePlug AV (GIT revision %s)\n\n", GIT_REV);
-	fprintf(stdout, "Modifications for better IEEE-1901-2010 conformance by Andrew Margolis\n\n");
 
 	if (argc < 2) {
 		usage();


### PR DESCRIPTION
This fork has been made in order to better decode HP-AV frames in sniffer mode according to the IEEE 1901-2010 standard.

Specifically, the modules homeplug_av.h and frame.c have had structures and functions added for decoding frames differentially according to delimiter type, and also for decoding beacon MPDU payload.  Various changes made to better describe fields and give values in both decimal and hex (and occasionally binary).

Tested using Debian GNU/Linux 8 with a variety of Homeplug adapters having both QCA and Broadcmm chipsets.  (Obviously, the Broadcom chipsets don't implement the Intellon/QCA proprietary sniffer mode, but the frames they emit can be successfully sniffed once an Intellon/QCA adapter is added to a Broadcmm Homeplug network).
