### PR TITLE
sha2.c: explicitly include endian.h for BYTE_ORDER macro

### DIFF
--- a/sha2.c
+++ b/sha2.c
@@ -40,6 +40,7 @@
 #include <inttypes.h>
 #include <string.h>
 
+#include "endian.h"
 #include "sha2.h"
 
 /*


### PR DESCRIPTION
Fixes a build issue with the musl C library, which doesn't indirectly
include endian.h from any of the included system headers:

http://autobuild.buildroot.net/results/17b/17bde543db253c008079b04c5e341f804160f59c/build-end.log

Signed-off-by: Peter Korsgaard <peter@korsgaard.com>