### PR TITLE
hpav_cfg.c: do not include linux/if_ether.h for musl compatibility

### DIFF
--- a/hpav_cfg.c
+++ b/hpav_cfg.c
@@ -53,8 +53,6 @@
 #include <arpa/inet.h>
 #include <net/if.h>
 
-#include <linux/if_ether.h>
-
 #include "homeplug_av.h"
 #include "crypto.h"
 


### PR DESCRIPTION
Fixes a build issue with the musl C library
http://autobuild.buildroot.net/results/dc6/dc6e4d7327d2031ef921cccd814605dec73a0f9c/build-end.log

Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>